### PR TITLE
Initial pass at very basic rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  */
 
 const allRules = {
-    // Add rules here once they exist!
+    'must-tear-down-animations': require('./lib/rules/must-tear-down-animations'),
 };
 
 // Set up rules to trigger errors (rather than warnings)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,34 @@
+/**
+ * Entry point configuration for the react-native animation linter.
+ */
+
+const allRules = {
+    // Add rules here once they exist!
+};
+
+// Set up rules to trigger errors (rather than warnings)
+function configureAsError(rules) {
+    const result = {};
+    for (const key in rules) {
+        if (!rules.hasOwnProperty(key)) {
+            continue;
+        }
+        result['react-native-animation-linter/' + key] = 2;
+    }
+    return result;
+}
+
+module.exports = {
+    rules: allRules,
+    configs: {
+        // default "all" configuration treats all rules as errors
+        all: {
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true,
+                },
+            },
+            rules: configureAsError(allRules),
+        },
+    },
+};

--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -1,0 +1,37 @@
+/**
+ * Attempts to enforce that animations are torn down when component unmounts.
+ */
+
+const create = (context) => {
+
+    /**
+     * Report teardown violations (animations that are set but not
+     * torn down in componentWillUnmount)
+     */
+    function reportMissingTeardowns(errorNodes) {
+        // Iterate through all nodes failing the lint rule
+        // and use context.report to surface error to user.
+        errorNodes.forEach(node => {
+            context.report({
+                node: node,
+                message: 'Must tear down animation on unmount',
+            });
+        });
+    }
+    // List where we will accumulate nodes violating the rule.
+    const errorNodes = [];
+    return {
+        Program: () => reportMissingTeardowns(errorNodes),
+    };
+};
+
+module.exports = {
+    meta: {
+        docs: {
+            description: 'Teardown animations in `componentWillUnmount`',
+            category: 'react-native',
+            recommended: true,
+        },
+    },
+    create,
+}

--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -72,7 +72,7 @@ const create = (context) => {
     function _getStateUpdate(node) {
         if (node.callee && node.callee.property &&
             node.callee.property.name === "setState") {
-            // We assume setState always takes a single argument.
+            // We assume the first argument to setState is the new state;
             return node.arguments[0];
         }
     }

--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -121,7 +121,8 @@ const create = (context) => {
         statements.forEach(statement => {
             const isTeardown = astHelpers.isAnimationTeardown(statement)
             if (isTeardown) {
-                const propertyName = astHelpers.getAnimationVariable(statement)
+                const propertyName = astHelpers.getTornDownAnimationState(
+                    statement);
                 delete activeAnimations[propertyName];
             }
         });

--- a/lib/rules/must-tear-down-animations.js
+++ b/lib/rules/must-tear-down-animations.js
@@ -1,27 +1,154 @@
 /**
  * Attempts to enforce that animations are torn down when component unmounts.
  */
+const {astHelpers} = require('../util/animations');
 
 const create = (context) => {
+
+    // TODO(amy): express this in a way where names are scoped
+    // within a single component to handle multi-component cases.
+    // Using a flat object temporarily to get the simplest cases covered.
+
+    // Stores all animated values that have been set.
+    // When an animation is torn down, it is removed.
+    const activeAnimations = {};
 
     /**
      * Report teardown violations (animations that are set but not
      * torn down in componentWillUnmount)
      */
-    function reportMissingTeardowns(errorNodes) {
+    function reportMissingTeardowns() {
+        // Get list of all animated nodes that remain active (not torn down)
+        const activeNodes = Object.values(activeAnimations);
         // Iterate through all nodes failing the lint rule
         // and use context.report to surface error to user.
-        errorNodes.forEach(node => {
+        activeNodes.forEach(node => {
             context.report({
                 node: node,
-                message: 'Must tear down animation on unmount',
+                message: `Must tear down animations when component unmounts`,
             });
         });
     }
-    // List where we will accumulate nodes violating the rule.
-    const errorNodes = [];
+
+    /**
+     * Check state initialization. If state is set to an animated value
+     * directly we record the animation.
+     */
+    function checkAnimatedStateInitialization(node) {
+        const stateProperty = _getStateInitialization(node);
+        if (stateProperty) {
+            // If initializing state with an animation directly, record the animation
+            const expression = node.value.callee;
+            const isAnimation = astHelpers.isAnimationDeclaration(expression);
+            if (isAnimation) {
+                activeAnimations[stateProperty] = node.value;
+            }
+        }
+    }
+
+    /**
+     * Check setState calls. If state is set to an animated value directly,
+     * we record the animation.
+     */
+    function checkSetState(node) {
+        const newState = _getStateUpdate(node);
+        if (newState) {
+            newState.properties.forEach(p => {
+                const stateProperty = p.key.name;
+                const value = p.value;
+                // If setting state to an animation directly, record the animation
+                const isAnimation = astHelpers.isAnimationDeclaration(value.callee);
+                if (isAnimation) {
+                    activeAnimations[stateProperty] = value;
+                }
+            })
+        }
+    }
+
+    /**
+     * Detect if state is being set via setState (`this.setState({foo: "bar"})`).
+     * Returns the new state object.
+     */
+    function _getStateUpdate(node) {
+        if (node.callee && node.callee.property &&
+            node.callee.property.name === "setState") {
+            // We assume setState always takes a single argument.
+            return node.arguments[0];
+        }
+    }
+
+
+    /**
+     * Checks for different ways of initializing state.
+     */
+    function _getStateInitialization(node) {
+        if (node.parent.type === "ObjectExpression") {
+            // Handle ES6 class property declaration
+            const objectExpression = node.parent;
+            const maybeState = objectExpression.parent;
+            if (maybeState.type === "ClassProperty" &&
+                maybeState.key.name === "state") {
+                return node.key.name;
+            }
+            // Handle this.state = {} syntax (constructor initialization)
+            if (objectExpression.parent.type === "AssignmentExpression") {
+                const left = objectExpression.parent.left;
+                if (left.object.type == "ThisExpression" &&
+                    left.property.name == "state") {
+                    return node.key.name;
+                }
+            }
+            // Handle getInitialState syntax
+            let currNode = node.parent;
+            while (currNode) {
+                if (currNode.type === 'FunctionExpression' &&
+                    currNode.parent.key.name === "getInitialState") {
+                    return node.key.name
+                }
+                currNode = currNode.parent;
+            }
+        }
+    }
+
+    /**
+     * Checks for animation teardowns in componentWillUnmount
+     */
+    function checkComponentWillUnmountForTeardown(node) {
+        if (node.key.name !== "componentWillUnmount") {
+            return;
+        }
+        const statements = node.value.body.body;
+        statements.forEach(statement => {
+            const isTeardown = astHelpers.isAnimationTeardown(statement)
+            if (isTeardown) {
+                const propertyName = astHelpers.getAnimationVariable(statement)
+                delete activeAnimations[propertyName];
+            }
+        });
+    }
+
     return {
-        Program: () => reportMissingTeardowns(errorNodes),
+
+        MethodDefinition: (node) => {
+            // componentWillUnmount can be a method
+            checkComponentWillUnmountForTeardown(node);
+        },
+
+        Property: (node) => {
+            // componentWillUnmount can be a property
+            checkComponentWillUnmountForTeardown(node);
+            // Animation state can be declared as an object property
+            checkAnimatedStateInitialization(node);
+        },
+
+        CallExpression: (node) => {
+            // Animation state can also be set via setState
+            checkSetState(node);
+        },
+
+        'Program:exit': () => {
+            reportMissingTeardowns();
+        }
     };
 };
 

--- a/lib/util/animations.js
+++ b/lib/util/animations.js
@@ -1,0 +1,33 @@
+
+const astHelpers = {
+    isAnimationDeclaration: function (node) {
+        // Capture the "Animated" in "Animated.Value(0)"
+        const objectMatch = (
+            node && node.object && node.object.name === "Animated");
+        // Capture the "Value" in "Animated.Value(0)"
+        const propertyMatch = (
+            node && node.property && node.property.name === "Value");
+        return Boolean(objectMatch && propertyMatch);
+    },
+
+    // Detect an animation teardown (stopAnimation()) event.
+    isAnimationTeardown: function (node) {
+        return Boolean(
+            node.expression &&
+            node.expression.callee &&
+            node.expression.callee.property &&
+            node.expression.callee.property.name === "stopAnimation"
+        );
+    },
+
+    // Detect state property that is being torn down.
+    // e.g. in this.state.color.stopAnimation() ==> return "color".
+    getTornDownAnimationState: function (node) {
+        const object = node.expression.callee.object;
+        return object.property && object.property.name;
+    },
+};
+
+module.exports = {
+    astHelpers,
+}


### PR DESCRIPTION
Depends on https://github.com/Khan/react-native-animation-linter/pull/2

This diff adds support for a few very simple test cases. It detects animation creation in some simple cases where state is directly set to an animated value, and detects the standard `this.state.foo.stopAnimation()` teardown in componentWillUnmount. There's still a whoooole bunch of cases we don't cover (5 of 22 still failing), but this gets us the most basic ones where the state is directly set to Animatee.Value

Test Plan:
npm run test --> confirm that some basic invalid cases are now being caught
